### PR TITLE
[DOCU-2635] Product name variables

### DIFF
--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -64,3 +64,8 @@ jekyll-generator-single-source:
   layout: 'page'
   multiple_products: false
   base_dest_path: 'docs'
+
+# Product name variables
+base_gateway: Kong Gateway
+mesh_product_name: Kuma
+kic_product_name: Kubernetes Ingress Controller

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -22,28 +22,31 @@ links:
 fb:
   app_id: 682375632267551
 twitter:
-  handle: '@KumaMesh'
+  handle: "@KumaMesh"
 
 defaults:
-  -
-    scope:
+  - scope:
       path: "_posts"
       type: "posts"
     values:
       layout: "post"
       permalink: "/blog/:year/:slug/"
-  -
-    scope:
+  - scope:
       path: "docs"
     values:
       layout: "page"
+
+# Product name variables
+base_gateway: Kong Gateway
+mesh_product_name: Kuma
+kic_product_name: Kubernetes Ingress Controller
 
 # Pagination
 pagination:
   # Site-wide kill switch, disabled here it doesn't run at all
   enabled: true
   per_page: 5
-  title: 'Page :num | :title'
+  title: "Page :num | :title"
   sort_reverse: true
   trail:
     before: 1
@@ -51,21 +54,21 @@ pagination:
 
 # Pardot
 pardot:
-  communityCallFormEndpoint: 'https://go.pardot.com/l/392112/2020-02-28/bl766m'
-  communityCallInvite: 'https://calendar.google.com/calendar?cid=a29uZ2hxLmNvbV8xbWE5NnNzZGdnZmg5ZnJyY3M5N2VwdTM4b0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t'
-  newsletterFormEndpoint: 'https://go.pardot.com/l/392112/2019-09-03/bjz6yv'
-  serviceMeshConFormEndpoint: 'https://go.konghq.com/l/392112/2020-11-16/bnlpqv'
+  communityCallFormEndpoint: "https://go.pardot.com/l/392112/2020-02-28/bl766m"
+  communityCallInvite: "https://calendar.google.com/calendar?cid=a29uZ2hxLmNvbV8xbWE5NnNzZGdnZmg5ZnJyY3M5N2VwdTM4b0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t"
+  newsletterFormEndpoint: "https://go.pardot.com/l/392112/2019-09-03/bjz6yv"
+  serviceMeshConFormEndpoint: "https://go.konghq.com/l/392112/2020-11-16/bnlpqv"
 
 # Analytics
 gtag:
-  tracking_id: 'UA-8499472-30'
+  tracking_id: "UA-8499472-30"
 
 jekyll-generator-single-source:
-  versions_file: '_data/versions.yml'
-  docs_nav_folder: '_data'
-  layout: 'page'
+  versions_file: "_data/versions.yml"
+  docs_nav_folder: "_data"
+  layout: "page"
   multiple_products: false
-  base_dest_path: 'docs'
+  base_dest_path: "docs"
 
 # Static files
 include:


### PR DESCRIPTION
Adding product name variables for mesh, gateway, and KIC. They're currently matching what we have on docs.konghq.com here: https://github.com/Kong/docs.konghq.com/blob/main/jekyll.yml#L174-L184

I only added those three variables for now as the only ones that _should_ appear in Kuma.

To use a variable in content, use the tag `{{site.<some_name>}}`. For example, `{{site.mesh_product_name}}`.

https://konghq.atlassian.net/browse/DOCU-2635